### PR TITLE
fix: ModuleNotFoundError: No module named 'games.handlers'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def package_data(pkg, roots):
 
 setup(
     name="edx-games",
-    version="1.0.0",
+    version="1.0.1",
     description="Interactive games XBlock for Open edX - Create flashcards and matching games with image support",
     author="edX",
     author_email="edx@edx.org",
@@ -29,6 +29,7 @@ setup(
     license="AGPL v3",
     packages=[
         "games",
+        "games.handlers",
     ],
     install_requires=[
         "XBlock>=1.2.0",


### PR DESCRIPTION
error log:
```
File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/games/__init__.py", line 1, in <module>
    from .games import GamesXBlock
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/games/games.py", line 9, in <module>
    from .handlers import CommonHandlers, FlashcardsHandlers, MatchingHandlers
ModuleNotFoundError: No module named 'games.handlers'
```