### PR TITLE
fix(ui): keep matching play again button colors consistent on hover

### DIFF
--- a/games/static/css/matching.css
+++ b/games/static/css/matching.css
@@ -168,6 +168,10 @@
     transition: background 0.2s ease;
 }
 
+.matching-end-button:hover:not(:disabled) {
+    background: var(--primary-500, #001A1D);
+}
+
 .matching-start-button:hover:not(:disabled) {
     background: var(--primary-600, #001A1D);
 }

--- a/games/static/css/matching.css
+++ b/games/static/css/matching.css
@@ -169,7 +169,7 @@
 }
 
 .matching-end-button:hover:not(:disabled) {
-    background: var(--primary-500, #001A1D);
+    background: var(--primary-600, #001A1D);
 }
 
 .matching-start-button:hover:not(:disabled) {

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def package_data(pkg, roots):
 
 setup(
     name="edx-games",
-    version="1.0.7",
+    version="1.0.8",
     description="Interactive games XBlock for Open edX - Create flashcards and matching games with image support",
     author="edX",
     author_email="edx@edx.org",


### PR DESCRIPTION
**Description**


 
- The “Play Again” button in the Matching game was changing to an unintended light grey background with white text on hover. This behavior conflicted with the intended design.

- This PR ensures the button maintains its original black background and white text when hovered (as long as it’s not disabled), aligning hover behavior with the default button state.

**Before**
<img width="833" height="616" alt="image (8)" src="https://github.com/user-attachments/assets/326ce583-aa61-45f4-9821-c2813fc66a15" />

**After**
<img width="1032" height="693" alt="image (9)" src="https://github.com/user-attachments/assets/40afa562-30c4-4591-aa2c-d89ccb0188b4" />



**Jira**
- https://2u-internal.atlassian.net/browse/TNL2-488

**Testing**
- Manually verified hover behavior on the “Play Again” button
- Confirmed disabled state remains unaffected


 