### PR TITLE
fix: auto-start matching game on Play Again

### DIFF
--- a/games/static/js/src/matching.js
+++ b/games/static/js/src/matching.js
@@ -48,7 +48,6 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
     }
 
     function refreshGame() {
-        MatchInit = null;
         $.ajax({
             type: 'GET',
             url: runtime.handlerUrl(element, 'refresh_game'),
@@ -61,9 +60,22 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
                     var scriptContent = decoderScript.text();
                     decoderScript.remove();
                     try {
-                        eval(scriptContent);
-                        if (typeof MatchingInit === 'function') {
-                            MatchingInit(runtime, element);
+                        var match = scriptContent.match(/function\s+(\w+)\s*\(/);
+                        if (match) {
+                            var initFuncName = match[1];
+                            eval(scriptContent);
+                            if (typeof window[initFuncName] === 'function') {
+                                window[initFuncName](runtime, element);
+                                setTimeout(function() {
+                                    $('.matching-start-button', element).click();
+                                }, 100);
+                            } else {
+                                console.error('Init function not found:', initFuncName);
+                                window.location.reload();
+                            }
+                        } else {
+                            console.error('Could not extract function name');
+                            window.location.reload();
                         }
                     } catch (err) {
                         console.error('Failed to initialize game:', err);

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def package_data(pkg, roots):
 
 setup(
     name="edx-games",
-    version="1.0.8",
+    version="1.0.9",
     description="Interactive games XBlock for Open edX - Create flashcards and matching games with image support",
     author="edX",
     author_email="edx@edx.org",


### PR DESCRIPTION
**Description**

- Fixes an issue where the Play Again button in the matching game required users to manually click Start before the game began.
- The game now reinitializes and automatically starts after refreshing, providing a smoother replay experience.

**Jira**

- https://2u-internal.atlassian.net/browse/TNL2-504

**Bump Version**

- 1.0.9