### PR TITLE
fix: update default title and improve styling

### DIFF
--- a/games/games.py
+++ b/games/games.py
@@ -20,7 +20,7 @@ class GamesXBlock(XBlock):
     """
 
     title = String(
-        default=DEFAULT.MATCHING_TITLE,
+        default=DEFAULT.FLASHCARDS_TITLE,
         scope=Scope.content,
         help=_("The title of the block to be displayed in the xblock."),
     )

--- a/games/static/css/flashcards.css
+++ b/games/static/css/flashcards.css
@@ -29,7 +29,7 @@
 .flashcards-title {
     color: var(--primary-500, #00262B);
     font-size: 24px;
-    font-weight: 600;
+    font-weight: 700;
     line-height: 32px;
     margin: 0;
 }
@@ -52,7 +52,10 @@
 
 .flashcards-start-title {
     color: var(--primary-500, #00262B);
+    text-align: center;
+    font-family: Inter;
     font-size: 20px;
+    font-style: normal;
     font-weight: 500;
     line-height: 28px;
 }

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def package_data(pkg, roots):
 
 setup(
     name="edx-games",
-    version="1.0.9",
+    version="1.0.10",
     description="Interactive games XBlock for Open edX - Create flashcards and matching games with image support",
     author="edX",
     author_email="edx@edx.org",

--- a/tests/test_games.py
+++ b/tests/test_games.py
@@ -55,7 +55,7 @@ class TestGamesXBlock:
                 user_id='test-user-id',
             )
         )
-        assert default_block.title == DEFAULT.MATCHING_TITLE
+        assert default_block.title == DEFAULT.FLASHCARDS_TITLE
         assert default_block.display_name == DEFAULT.DISPLAY_NAME
         assert default_block.game_type == DEFAULT.GAME_TYPE
         assert default_block.cards == []


### PR DESCRIPTION
**Description**

- Changes the default flashcards XBlock title from the matching title to the flashcards title.
- Updates flashcard title styles to improve emphasis, alignment, and consistency.
 