### PR TITLE
feat(flashcards): add alt text support for term and definition images

### DIFF
--- a/games/constants.py
+++ b/games/constants.py
@@ -34,6 +34,8 @@ class CARD_FIELD:
     DEFINITION = "definition"
     DEFINITION_IMAGE = "definition_image"
     ORDER = "order"
+    TERM_IMAGE_ALT = "term_image_alt"
+    DEFINITION_IMAGE_ALT = "definition_image_alt"
 
 
 class CONTAINER_TYPE:

--- a/games/handlers/common.py
+++ b/games/handlers/common.py
@@ -217,6 +217,8 @@ class CommonHandlers:
                         CARD_FIELD.CARD_KEY: card.get(
                             CARD_FIELD.CARD_KEY, str(uuid.uuid4())
                         ),
+                        CARD_FIELD.TERM_IMAGE_ALT: card.get(CARD_FIELD.TERM_IMAGE_ALT, ""),
+                        CARD_FIELD.DEFINITION_IMAGE_ALT: card.get(CARD_FIELD.DEFINITION_IMAGE_ALT, ""),
                     }
                 )
 

--- a/games/handlers/flashcards.py
+++ b/games/handlers/flashcards.py
@@ -33,6 +33,14 @@ class FlashcardsHandlers:
         salt = "".join(random.choices(string.ascii_letters + string.digits, k=CONFIG.SALT_LENGTH))
         payload_cards = []
         for card in cards:
+            term_image_alt = card.get(CARD_FIELD.TERM_IMAGE_ALT, "").strip()
+            if not term_image_alt:
+                term_image_alt = card.get(CARD_FIELD.TERM, "")
+
+            definition_image_alt = card.get(CARD_FIELD.DEFINITION_IMAGE_ALT, "").strip()
+            if not definition_image_alt:
+                definition_image_alt = card.get(CARD_FIELD.DEFINITION, "")
+
             payload_cards.append(
                 {
                     "id": card.get(CARD_FIELD.CARD_KEY, ""),
@@ -40,6 +48,8 @@ class FlashcardsHandlers:
                     "definition": card.get(CARD_FIELD.DEFINITION, ""),
                     "term_image": card.get(CARD_FIELD.TERM_IMAGE, ""),
                     "definition_image": card.get(CARD_FIELD.DEFINITION_IMAGE, ""),
+                    "term_image_alt": term_image_alt,
+                    "definition_image_alt": definition_image_alt,
                 }
             )
         mapping_payload = {"cards": payload_cards, "salt": salt}

--- a/games/static/js/src/flashcards.js
+++ b/games/static/js/src/flashcards.js
@@ -38,14 +38,16 @@ function GamesXBlockFlashcardsInit(runtime, element, cards) {
 
         // Handle term image
         if (card.term_image && card.term_image.trim() !== '') {
-            $termImage.attr('src', card.term_image).attr('alt', card.term).show();
+            var termAlt = card.term_image_alt || card.term || '';
+            $termImage.attr('src', card.term_image).attr('alt', termAlt).show();
         } else {
             $termImage.hide();
         }
 
         // Handle definition image
         if (card.definition_image && card.definition_image.trim() !== '') {
-            $definitionImage.attr('src', card.definition_image).attr('alt', card.definition).show();
+            var defAlt = card.definition_image_alt || card.definition || '';
+            $definitionImage.attr('src', card.definition_image).attr('alt', defAlt).show();
         } else {
             $definitionImage.hide();
         }

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def package_data(pkg, roots):
 
 setup(
     name="edx-games",
-    version="1.0.11",
+    version="1.0.12",
     description="Interactive games XBlock for Open edX - Create flashcards and matching games with image support",
     author="edX",
     author_email="edx@edx.org",


### PR DESCRIPTION
**Description**

- Adds accessibility support for Flashcards images by introducing explicit alt text fields for term and definition images.

**Jira**

- https://2u-internal.atlassian.net/browse/TNL2-518

**Version**

- 1.0.12