### PR TITLE
fix: ensure next card resets to term side on navigation

### DIFF
--- a/games/static/css/flashcards.css
+++ b/games/static/css/flashcards.css
@@ -112,6 +112,10 @@
     cursor: pointer;
 }
 
+.flashcard-inner.no-transition {
+    transition: none;
+}
+
 .flashcard-block.flashcard-flipped .flashcard-inner {
     transform: rotateY(180deg);
 }

--- a/games/static/js/src/flashcards.js
+++ b/games/static/js/src/flashcards.js
@@ -22,6 +22,7 @@ function GamesXBlockFlashcardsInit(runtime, element, cards) {
     var $progress = $element.find('#flashcard-progress');
     var $prevBtn = $element.find('#flashcard-prev');
     var $nextBtn = $element.find('#flashcard-next');
+    var $inner = $element.find('.flashcard-inner');
 
     // Render current card
     function renderCard() {
@@ -59,9 +60,12 @@ function GamesXBlockFlashcardsInit(runtime, element, cards) {
         $prevBtn.prop('disabled', currentIndex === 0);
         $nextBtn.prop('disabled', currentIndex === totalCards - 1);
 
-        // Reset flip state
-        if ($card.hasClass(flipClassName)) {
+        // Reset flip state instantly (no animation)
+        if ($card.hasClass(flipClassName) && $inner.length) {
+            $inner.addClass('no-transition');
             $card.removeClass(flipClassName);
+            void $inner[0].offsetHeight;
+            $inner.removeClass('no-transition');
         }
     }
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def package_data(pkg, roots):
 
 setup(
     name="edx-games",
-    version="1.0.12",
+    version="1.0.13",
     description="Interactive games XBlock for Open edX - Create flashcards and matching games with image support",
     author="edX",
     author_email="edx@edx.org",


### PR DESCRIPTION
This PR fixes an issue in the Flashcard / Matching Test where, after flipping a card and navigating to the next one, the next card briefly renders on the back side (definition) before flipping to the front (item).

**Fix**
- Reset flashcard state on navigation to ensure each new card starts on the front side
- Ensure consistent initial render behavior across browsers

**JIRA**
- https://2u-internal.atlassian.net/browse/TNL2-553