### PR TITLE
fix: screen reader compatibility 

### DIFF
--- a/games/static/css/flashcards.css
+++ b/games/static/css/flashcards.css
@@ -317,3 +317,21 @@
     border-right: 8px solid transparent;
     border-top: 8px solid var(--primary-500, #00262B);
 }
+
+.gamesxblock-flashcards .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.flashcard-block:focus-visible {
+    outline: 2px solid var(--primary-500, #00262B);
+    outline-offset: 2px;
+    border-radius: 8px;
+}

--- a/games/static/css/matching.css
+++ b/games/static/css/matching.css
@@ -421,3 +421,25 @@
     opacity: 1;
     visibility: visible;
 }
+
+.gamesxblock-matching .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.matching-box:focus-visible {
+    outline: 2px solid var(--primary-500, #00262B);
+    outline-offset: 2px;
+    box-shadow: 0 0 0 4px rgba(0, 38, 43, 0.2);
+}
+
+.matching-end-screen-content:focus {
+    outline: none;
+}

--- a/games/static/html/flashcards.html
+++ b/games/static/html/flashcards.html
@@ -5,7 +5,8 @@
 <script type="application/json" id="{{data_element_id}}">{{encoded_mapping|safe}}</script>
 <script type="text/template" id="flashcards_decoder_script">{{obf_decoder|safe}}</script>
 
-<div class="gamesxblock gamesxblock-flashcards">
+<div class="gamesxblock gamesxblock-flashcards" role="region" aria-label="{% trans 'Flashcard game' %}">
+    <div class="sr-only" aria-live="assertive" aria-atomic="true" role="alert" id="flashcard-sr-announcements"></div>
     <!-- Header -->
     <div class="flashcards-header">
         <h1 class="flashcards-title">{{title}}</h1>
@@ -18,15 +19,15 @@
 
     <!-- Main Card Area -->
     <div class="flashcards-card-wrapper">
-        <div class="flashcard-block" id="flashcard-card" draggable="false" tabindex="0" role="button" aria-pressed="false">
+        <div class="flashcard-block" id="flashcard-card" draggable="false" tabindex="0" aria-roledescription="flashcard" aria-label="">
             <div class="flashcard-inner">
-                <div class="flashcard-face flashcard-front">
+                <div class="flashcard-face flashcard-front" aria-hidden="false">
                     <div class="flashcard-front-content">
                         <img id="flashcard-term-image" class="image" alt="Flashcard term" />
                         <div class="flashcard-text" id="flashcard-term">&nbsp;</div>
                     </div>
                 </div>
-                <div class="flashcard-face flashcard-back">
+                <div class="flashcard-face flashcard-back" aria-hidden="true">
                     <div class="flashcard-back-content">
                         <img id="flashcard-definition-image" class="image" alt="Flashcard definition" />
                         <div class="flashcard-text" id="flashcard-definition">&nbsp;</div>

--- a/games/static/html/matching.html
+++ b/games/static/html/matching.html
@@ -5,6 +5,7 @@
 <script type="text/template" id="obf_decoder_script">{{obf_decoder|safe}}</script>
 
 <div class='gamesxblock gamesxblock-matching' data-timed="{{ has_timer|yesno:'true,false' }}">
+    <div class="sr-only" aria-live="assertive" aria-atomic="true" role="alert" id="matching-sr-announcements"></div>
     <div class="matching-header">
         <h1 class="matching-title">{{title}}</h1>
     </div>
@@ -12,7 +13,7 @@
     <div class="matching-start-screen">
         <h1 class="matching-start-title">{% trans "Match each term with the correct definition" %}</h1>
         <button class="matching-start-button" {% if list_length <= 0 %}disabled{% endif %}>{% trans "Start" %}</button>
-        <div class="matching-loading-spinner">
+        <div class="matching-loading-spinner" aria-hidden="true">
             <div class="spinner"></div>
         </div>
     </div>
@@ -23,7 +24,8 @@
             {% if all_pages %}
                 {% for item in all_pages.0.left_items %}
                 <div class="matching-box-wrapper">
-                    <div class="matching-box" data-index="matching-key-{{item.index}}" title="{{item.text}}">
+                    <div class="matching-box" data-index="matching-key-{{item.index}}" data-item-type="term"
+                         title="{{item.text}}" role="button" tabindex="0">
                         <span class="matching-box-text">{{item.text}}</span>
                     </div>
                 </div>
@@ -36,7 +38,8 @@
             {% if all_pages %}
                 {% for item in all_pages.0.right_items %}
                 <div class="matching-box-wrapper">
-                    <div class="matching-box" data-index="matching-key-{{item.index}}" title="{{item.text}}">
+                    <div class="matching-box" data-index="matching-key-{{item.index}}" data-item-type="definition"
+                         title="{{item.text}}" role="button" tabindex="0">
                         <span class="matching-box-text">{{item.text}}</span>
                     </div>
                 </div>
@@ -48,7 +51,7 @@
     <div class="matching-footer">
         <div class="matching-progress-wrapper">
             {% if total_pages > 1 %}
-            <svg class="matching-progress-circle" xmlns="http://www.w3.org/2000/svg" width="55" height="55" viewBox="0 0 55 55" fill="none">
+            <svg class="matching-progress-circle" xmlns="http://www.w3.org/2000/svg" width="55" height="55" viewBox="0 0 55 55" fill="none" aria-hidden="true">
                 <circle class="matching-progress-bg" cx="27.0213" cy="27.0213" r="25.0213" stroke-width="4" />
                 <circle class="matching-progress-bar" cx="27.0213" cy="27.0213" r="25.0213" stroke-width="4" />
             </svg>
@@ -75,7 +78,7 @@
 
     <div class="matching-end-screen">
         <div class="confetti-container"></div>
-        <div class="matching-end-screen-content">
+        <div class="matching-end-screen-content" tabindex="-1" role="region" aria-label="{% trans 'Game results' %}">
             <h1 class="matching-end-title">{% trans "Congratulations!" %}</h1>
             <div class="matching-new-best">
                 <h1 class="matching-new-end-title" id="matching-current-result">0:00</h1>

--- a/games/static/js/src/flashcards.js
+++ b/games/static/js/src/flashcards.js
@@ -23,6 +23,24 @@ function GamesXBlockFlashcardsInit(runtime, element, cards) {
     var $prevBtn = $element.find('#flashcard-prev');
     var $nextBtn = $element.find('#flashcard-next');
     var $inner = $element.find('.flashcard-inner');
+    var $liveRegion = $element.find('#flashcard-sr-announcements');
+
+    function announce(message) {
+        var el = $liveRegion[0];
+        el.textContent = '';
+        // Force reflow so the screen reader registers the cleared state
+        void el.offsetHeight;
+        el.textContent = message;
+    }
+
+    function getCardAriaLabel() {
+        var card = cards[currentIndex];
+        var isFlipped = $card.hasClass(flipClassName);
+        if (isFlipped) {
+            return 'Flashcard ' + (currentIndex + 1) + ' of ' + totalCards + '. Definition: ' + (card.definition || '') + '. Press Enter or Space to flip.';
+        }
+        return 'Flashcard ' + (currentIndex + 1) + ' of ' + totalCards + '. Term: ' + (card.term || '') + '. Press Enter or Space to flip.';
+    }
 
     // Render current card
     function renderCard() {
@@ -67,15 +85,34 @@ function GamesXBlockFlashcardsInit(runtime, element, cards) {
             void $inner[0].offsetHeight;
             $inner.removeClass('no-transition');
         }
+        $element.find('.flashcard-front').attr('aria-hidden', 'false');
+        $element.find('.flashcard-back').attr('aria-hidden', 'true');
+        $card.attr('aria-label', getCardAriaLabel());
+        announce('Card ' + (currentIndex + 1) + ' of ' + totalCards + '. Term: ' + (card.term || ''));
     }
 
     // Flip card
     function flipCard() {
-        if ($card.hasClass(flipClassName)) {
+        var isFlipped = $card.hasClass(flipClassName);
+        if (isFlipped) {
             $card.removeClass(flipClassName);
+            $element.find('.flashcard-front').attr('aria-hidden', 'false');
+            $element.find('.flashcard-back').attr('aria-hidden', 'true');
         } else {
             $card.addClass(flipClassName);
+            $element.find('.flashcard-front').attr('aria-hidden', 'true');
+            $element.find('.flashcard-back').attr('aria-hidden', 'false');
         }
+        var card = cards[currentIndex];
+        if ($card.hasClass(flipClassName)) {
+            announce('Definition: ' + (card.definition || ''));
+        } else {
+            announce('Term: ' + (card.term || ''));
+        }
+        // Update aria-label after announce so it doesn't compete
+        setTimeout(function() {
+            $card.attr('aria-label', getCardAriaLabel());
+        }, 1000);
     }
 
     // Navigation
@@ -99,6 +136,7 @@ function GamesXBlockFlashcardsInit(runtime, element, cards) {
         $cardWrapper.addClass('active');
         $footer.addClass('active');
         renderCard();
+        $card.focus();
     }
 
     // Event handlers
@@ -138,11 +176,20 @@ function GamesXBlockFlashcardsInit(runtime, element, cards) {
                 break;
             case ' ':
             case 'Enter':
-                e.preventDefault();
-                flipCard();
+                // Only flip when the card itself is focused, not buttons
+                if ($(e.target).is($card) || $card.find(e.target).length) {
+                    e.preventDefault();
+                    flipCard();
+                }
                 break;
         }
     });
+
+    // Focus the start button on load and announce the game
+    setTimeout(function() {
+        $startButton.focus();
+        announce('Flashcard game. Press Start to begin.');
+    }, 300);
 
     // Cleanup on unload
     $(element).on('remove', function() {

--- a/games/static/js/src/matching.js
+++ b/games/static/js/src/matching.js
@@ -5,6 +5,16 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
 
     if (!container.length || !pages || pages.length === 0) return;
 
+    var $liveRegion = $(element).find('#matching-sr-announcements');
+
+    function announce(message) {
+        var el = $liveRegion[0];
+        el.textContent = '';
+        // Force reflow so the screen reader registers the cleared state
+        void el.offsetHeight;
+        el.textContent = message;
+    }
+
     // Prevent duplicate init that would attach multiple handlers
     if (container.data('gx_matching_initialized')) {
         return;
@@ -138,6 +148,9 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
                     if (has_timer) {
                         startTimer();
                     }
+                    setTimeout(function() {
+                        $('.matching-box', element).first().focus();
+                    }, 100);
                 } else {
                     alert('Error loading game: ' + (response.error || 'Unknown error'));
                     spinner.removeClass('active');
@@ -168,6 +181,9 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
                     if (has_timer) {
                         startTimer();
                     }
+                    setTimeout(function() {
+                        $('.matching-box', element).first().focus();
+                    }, 100);
                     spinner.removeClass('active');
                     return;
                 }
@@ -220,11 +236,13 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
 
     function clearSelectionVisual(box) {
         box.removeClass('selected incorrect');
+        box.attr('aria-pressed', 'false');
     }
 
     function markIncorrect(a, b) {
         a.addClass('incorrect');
         b.addClass('incorrect');
+        announce('Incorrect match. Try again.');
         setTimeout(() => {
             clearSelectionVisual(a);
             clearSelectionVisual(b);
@@ -256,7 +274,10 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
             const wrapper = $('<div class="matching-box-wrapper"></div>');
             const box = $('<div class="matching-box"></div>')
                 .attr('data-index', `matching-key-${item.index}`)
-                .attr('title', item.text);
+                .attr('data-item-type', 'term')
+                .attr('title', item.text)
+                .attr('role', 'button')
+                .attr('tabindex', '0');
             const text = $('<span class="matching-box-text"></span>').text(item.text);
             box.append(text);
             wrapper.append(box);
@@ -268,7 +289,10 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
             const wrapper = $('<div class="matching-box-wrapper"></div>');
             const box = $('<div class="matching-box"></div>')
                 .attr('data-index', `matching-key-${item.index}`)
-                .attr('title', item.text);
+                .attr('data-item-type', 'definition')
+                .attr('title', item.text)
+                .attr('role', 'button')
+                .attr('tabindex', '0');
             const text = $('<span class="matching-box-text"></span>').text(item.text);
             box.append(text);
             wrapper.append(box);
@@ -277,27 +301,54 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
 
         // Re-attach click handlers to new boxes
         attachBoxClickHandlers();
+        $('.matching-box', element).first().focus();
+        announce('Page ' + (currentPageIndex + 1) + ' of ' + totalPages);
     }
 
     function markMatch(a, b) {
         a.addClass('matched').removeClass('selected');
         b.addClass('matched').removeClass('selected');
+        announce('Correct match!');
         matchCount += 1;
+
+        // Delay aria state changes so VoiceOver finishes reading "Correct match!" first
+        setTimeout(function() {
+            a.attr('aria-disabled', 'true').attr('aria-pressed', 'false');
+            b.attr('aria-disabled', 'true').attr('aria-pressed', 'false');
+        }, 1500);
 
         // Check if current page is complete
         if (matchCount >= currentPagePairs) {
             // Check if there are more pages
             if (currentPageIndex + 1 < totalPages) {
-                loadNextPage();
+                // Delay so "Correct match!" is heard before "Page X of Y"
+                setTimeout(function() {
+                    loadNextPage();
+                }, 1500);
             } else {
                 // All pages complete - end game
                 if (has_timer) {
                     stopTimer();
                 }
+                // Delay so "Correct match!" is heard before "Congratulations"
                 setTimeout(() => {
                     completeGame();
-                }, 800);
+                }, 1500);
             }
+            return;
+        }
+
+        // Determine next focus target before boxes are removed from the DOM.
+        // Look for the nearest unmatched box after the last clicked box (b),
+        // then before it in the same column, then any remaining unmatched box.
+        var $nextFocus = b.parent().nextAll('.matching-box-wrapper')
+            .find('.matching-box:not(.matched)').first();
+        if (!$nextFocus.length) {
+            $nextFocus = b.parent().prevAll('.matching-box-wrapper')
+                .find('.matching-box:not(.matched)').first();
+        }
+        if (!$nextFocus.length) {
+            $nextFocus = $('.matching-box:not(.matched)', element).first();
         }
 
         setTimeout(() => {
@@ -306,6 +357,11 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
                     $(this).remove();
                 });
             });
+            setTimeout(function() {
+                if ($nextFocus.length) {
+                    $nextFocus.focus();
+                }
+            }, 650);
         }, 1500);
     }
 
@@ -320,6 +376,8 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
             if (typeof GamesConfetti !== 'undefined') {
                 GamesConfetti.trigger($('.confetti-container', element), 20);
             }
+            announce('Congratulations! You matched all items.');
+            $('.matching-end-screen-content', element).focus();
             return;
         }
 
@@ -336,6 +394,8 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
             if (typeof GamesConfetti !== 'undefined') {
                 GamesConfetti.trigger($('.confetti-container', element), 20);
             }
+            announce('Congratulations! You matched all items.');
+            $('.matching-end-screen-content', element).focus();
             return;
         }
 
@@ -373,6 +433,8 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
                 if (typeof GamesConfetti !== 'undefined') {
                     GamesConfetti.trigger($('.confetti-container', element), 20);
                 }
+                announce('Congratulations! You matched all items.');
+                $('.matching-end-screen-content', element).focus();
             },
             error: function(xhr, status, error) {
                 console.error('Failed to submit score:', error);
@@ -396,6 +458,7 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
         }
 
         box.addClass('selected');
+        box.attr('aria-pressed', 'true');
         if (!firstSelection) {
             firstSelection = [box, idx];
             return;
@@ -421,9 +484,19 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
     }
 
     function attachBoxClickHandlers() {
-        $('.matching-box', element).off('click').on('click', handleBoxClick);
+        $('.matching-box', element).off('click keydown')
+            .on('click', handleBoxClick)
+            .on('keydown', function(e) {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleBoxClick.call(this);
+                }
+            });
     }
 
     attachBoxClickHandlers();
+
+    // Set initial focus on the start button so keyboard users land on the game
+    $('.matching-start-button', element).focus();
 }
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def package_data(pkg, roots):
 
 setup(
     name="edx-games",
-    version="1.0.13",
+    version="1.0.14",
     description="Interactive games XBlock for Open edX - Create flashcards and matching games with image support",
     author="edX",
     author_email="edx@edx.org",


### PR DESCRIPTION
 - Add screen reader announcements via aria-live regions for both flashcards and matching games, so users hear card flips, correct/incorrect matches, page transitions, and game completion
  - Add keyboard navigation support to matching game boxes (role="button", tabindex="0", Enter/Space key handlers) and manage focus throughout gameplay (start, navigation, after matches,
  end screen)
  - Add aria-hidden to decorative elements (loading spinner, progress SVG, card faces) and focus-visible outlines for keyboard users
  - Add sr-only CSS utility class for visually hidden but screen-reader-accessible content
  - Bumped up version to 1.0.14