### PR TITLE
feat(matching): match by text instead of IDs to support duplicates

### DIFF
--- a/games/games.py
+++ b/games/games.py
@@ -123,11 +123,6 @@ class GamesXBlock(XBlock):
         """Complete the matching game and compare the user's time to the best_time field."""
         return MatchingHandlers.complete_matching_game(self, data, suffix)
 
-    @XBlock.json_handler
-    def start_matching_game(self, data, suffix=""):
-        """Decrypt and return the key mapping for matching game validation."""
-        return MatchingHandlers.get_matching_key_mapping(self, data, suffix)
-
     @XBlock.handler
     def refresh_game(self, request, suffix=""):
         """Refresh the game view with new shuffled data."""

--- a/games/handlers/matching.py
+++ b/games/handlers/matching.py
@@ -4,144 +4,63 @@ Matching game handler methods.
 This module contains handlers specific to the matching game type.
 """
 
-import base64
-import json
+import hashlib
+import hmac as _hmac
 import random
-import string
+import secrets
 
 import pkg_resources
 from xblock.core import Response
 from django.template import Context, Template
 from web_fragments.fragment import Fragment
 from ..constants import CONFIG, DEFAULT
-from .common import CommonHandlers
 
 
 class MatchingHandlers:
     """Handlers specific to the matching game type."""
 
     @staticmethod
+    def _hmac_hex(key: str, text: str) -> str:
+        """Return HMAC-SHA256 hex digest of text using key."""
+        return _hmac.new(key.encode(), text.encode(), hashlib.sha256).hexdigest()
+
+    @staticmethod
     def student_view(xblock, context=None):
         """Render the student view for the matching game."""
-        # Prepare cards
         cards = list(xblock.cards) if xblock.cards else []
         list_length = len(cards)
+        session_key = secrets.token_hex(32)
 
-        # Split cards into pages based on MATCHES_PER_PAGE
         matches_per_page = CONFIG.MATCHES_PER_PAGE
         pages = []
         for i in range(0, len(cards), matches_per_page):
             page_cards = cards[i:i + matches_per_page]
-            pages.append(page_cards)
-
-        # Pre-generate all random keys in one batch (hex digits for maximum confusion)
-        total_items = len(cards) * 2
-        key_length = CONFIG.RANDOM_STRING_LENGTH
-        bits_needed = key_length * 4  # Each hex char = 4 bits
-        all_keys = [
-            format(random.getrandbits(bits_needed), f"0{key_length}x")
-            for _ in range(total_items)
-        ]
-
-        # Pre-allocate array with None slots (will be filled with {key, index} objects)
-        matched_entries = [None] * total_items
-        all_pages_data = []
-
-        # Process each page with unique incremental indices per item (term + definition distinct)
-        global_counter = 0
-        for _, page_cards in enumerate(pages):
             left_items = []
             right_items = []
-
             for card in page_cards:
-                # Generate term item
-                term_index = global_counter
-                term_key = all_keys[term_index]
-                term_text = card.get("term", "")
-                left_items.append({"text": term_text, "index": term_index})
-                global_counter += 1
-
-                # Generate definition item
-                def_index = global_counter
-                def_key = all_keys[def_index]
                 def_text = card.get("definition", "")
-                right_items.append({"text": def_text, "index": def_index})
-                global_counter += 1
-
-                # Add bidirectional mapping entries as UUID-like strings for obfuscation
-                matched_entries[term_index] = CommonHandlers.format_as_uuid_like(
-                    term_key, def_index
-                )
-                matched_entries[def_index] = CommonHandlers.format_as_uuid_like(
-                    def_key, term_index
-                )
-
-            # Shuffle left and right items per page if enabled
+                def_hash = MatchingHandlers._hmac_hex(session_key, def_text)
+                left_items.append({
+                    "text": card.get("term", ""),
+                    "match": def_hash,
+                })
+                right_items.append({"text": def_text, "hash": def_hash})
             if xblock.is_shuffled:
                 random.shuffle(left_items)
                 random.shuffle(right_items)
-
-            all_pages_data.append(
-                {"left_items": left_items, "right_items": right_items}
-            )
-
-        encryption_key = CommonHandlers.generate_encryption_key(xblock)
-        encrypted_hash = CommonHandlers.encrypt_data(matched_entries, encryption_key)
-
-        # Include all pages data in payload; encrypted "key" now holds list of pairs
-        mapping_payload = {"key": encrypted_hash, "pages": all_pages_data}
-        encoded_mapping = base64.b64encode(
-            json.dumps(mapping_payload).encode()
-        ).decode()
+            pages.append({"left_items": left_items, "right_items": right_items})
 
         total_pages = len(pages)
 
         template_context = {
             "title": getattr(xblock, "title", DEFAULT.MATCHING_TITLE),
             "list_length": list_length,
-            "all_pages": all_pages_data,
+            "all_pages": pages,
             "has_timer": getattr(xblock, "has_timer", DEFAULT.HAS_TIMER),
             "total_pages": total_pages,
+            "pages_json": pages,
+            "block_id": xblock.scope_ids.usage_id.block_id,
         }
-
-        var_names = CommonHandlers.generate_unique_var_names(
-            ["runtime", "elem", "tag", "payload", "err"], min_len=1, max_len=3
-        )
-
-        data_element_id = "".join(
-            random.choices(string.ascii_lowercase + string.digits, k=16)
-        )
-
-        # Generate unique function name per XBlock to avoid conflicts
-        init_function_name = "MatchingInit_" + "".join(
-            random.choices(string.ascii_lowercase + string.digits, k=8)
-        )
-
-        runtime = var_names["runtime"]
-        elem = var_names["elem"]
-        payload = var_names["payload"]
-
-        # Build obfuscated decoder function; initializes JS via payload
-        obf_decoder = (
-            f"function {init_function_name}({var_names['runtime']},{var_names['elem']}){{"
-            f"try{{"
-            f"var {var_names['tag']}=$('#{data_element_id}',{var_names['elem']});"
-            f"if(!{var_names['tag']}.length){{console.error('Matching: Data element not found');return;}}"
-            f"var {var_names['payload']}=JSON.parse(atob({var_names['tag']}.text()));"
-            f"{var_names['tag']}.remove();"
-            f"if({var_names['payload']}&&{var_names['payload']}.pages){{"
-            f"if(typeof GamesXBlockMatchingInit==='function'){{"
-            f"GamesXBlockMatchingInit({runtime},{elem},{payload}.pages,{payload}.key);"
-            f"}}else{{console.error('Matching: GamesXBlockMatchingInit not defined');}}"
-            f"}}else{{console.error('Matching: Invalid payload');}}"
-            f"$('#obf_decoder_script',{var_names['elem']}).remove();"
-            f"}}catch({var_names['err']}){{console.error('Matching decode failed:',{var_names['err']});}}}}"
-        )
-
-        template_context["encoded_mapping"] = encoded_mapping
-        template_context["obf_decoder"] = obf_decoder
-        template_context["data_element_id"] = data_element_id
-        template_context["init_function_name"] = init_function_name
 
         template_str = pkg_resources.resource_string(
             __name__, "../static/html/matching.html"
@@ -170,25 +89,8 @@ class MatchingHandlers:
                 __name__, "../static/js/src/confetti.js"
             ).decode("utf8")
         )
-        # Add decoder function AFTER main JS files so GamesXBlockMatchingInit is defined
-        frag.add_javascript(obf_decoder)
-        frag.initialize_js(init_function_name)
+        frag.initialize_js('GamesXBlockMatchingInit')
         return frag
-
-    @staticmethod
-    def get_matching_key_mapping(xblock, data, suffix=""):
-        """Decrypt and return the key mapping for matching game validation."""
-        try:
-            matching_key = data.get("matching_key")
-            if not matching_key:
-                return {"success": False, "error": "Missing matching_key parameter"}
-
-            encryption_key = CommonHandlers.generate_encryption_key(xblock)
-            key_mapping = CommonHandlers.decrypt_data(matching_key, encryption_key)
-
-            return {"success": True, "data": key_mapping, "mode": xblock.get_mode()}
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            return {"success": False, "error": f"Failed to decrypt mapping: {str(e)}"}
 
     @staticmethod
     def refresh_game(xblock, request, suffix=""):

--- a/games/static/html/matching.html
+++ b/games/static/html/matching.html
@@ -1,8 +1,7 @@
 {% load i18n %}
 <link href='https://fonts.googleapis.com/css?family=Inter' rel='stylesheet'>
 
-<script type="application/json" id="{{data_element_id}}">{{encoded_mapping|safe}}</script>
-<script type="text/template" id="obf_decoder_script">{{obf_decoder|safe}}</script>
+{{ pages_json|json_script:"matching-pages-data" }}
 
 <div class='gamesxblock gamesxblock-matching' data-timed="{{ has_timer|yesno:'true,false' }}">
     <div class="sr-only" aria-live="assertive" aria-atomic="true" role="alert" id="matching-sr-announcements"></div>
@@ -18,14 +17,14 @@
         </div>
     </div>
 
-    <main id="main-content-{{data_element_id}}" tabindex="-1">
+    <main id="main-content-{{block_id}}" tabindex="-1">
     <div class="matching-grid">
         <!-- Left Column (mixed when shuffled) -->
         <div class="matching-column matching-column-left">
             {% if all_pages %}
                 {% for item in all_pages.0.left_items %}
                 <div class="matching-box-wrapper">
-                    <div class="matching-box" data-index="matching-key-{{item.index}}" data-item-type="term"
+                    <div class="matching-box" data-item-type="term" data-match="{{item.match}}"
                          title="{{item.text}}" role="button" tabindex="0">
                         <span class="matching-box-text">{{item.text}}</span>
                     </div>
@@ -39,7 +38,7 @@
             {% if all_pages %}
                 {% for item in all_pages.0.right_items %}
                 <div class="matching-box-wrapper">
-                    <div class="matching-box" data-index="matching-key-{{item.index}}" data-item-type="definition"
+                    <div class="matching-box" data-item-type="definition" data-hash="{{item.hash}}"
                          title="{{item.text}}" role="button" tabindex="0">
                         <span class="matching-box-text">{{item.text}}</span>
                     </div>

--- a/games/static/js/src/matching.js
+++ b/games/static/js/src/matching.js
@@ -1,5 +1,9 @@
 /* Matching game isolated script */
-function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
+function GamesXBlockMatchingInit(runtime, element) {
+    const pagesEl = $(element).find('#matching-pages-data');
+    const pages = JSON.parse(pagesEl.text());
+    pagesEl.remove();
+
     const container = $('.gamesxblock-matching', element);
     const has_timer = $(container).data('timed') === true || $(container).data('timed') === 'true';
 
@@ -21,14 +25,12 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
     }
     container.data('gx_matching_initialized', true);
 
-    let indexLink = null; // maps self_index -> partner_index
     let allPages = pages;
     let currentPageIndex = 0;
     let totalPages = pages.length;
 
     let timerInterval = null;
     let timeSeconds = 0;
-    let isPreviewMode = false;
 
     function formatTime(seconds) {
         const hours = Math.floor(seconds / 3600);
@@ -64,36 +66,10 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
             dataType: 'html',
             success: function(html) {
                 $(element).html(html);
-                var decoderScript = $(element).find('#obf_decoder_script');
-
-                if (decoderScript.length) {
-                    var scriptContent = decoderScript.text();
-                    decoderScript.remove();
-                    try {
-                        var match = scriptContent.match(/function\s+(\w+)\s*\(/);
-                        if (match) {
-                            var initFuncName = match[1];
-                            (1, eval)(scriptContent);
-                            if (typeof window[initFuncName] === 'function') {
-                                window[initFuncName](runtime, element);
-                                setTimeout(function() {
-                                    $('.matching-start-button', element).click();
-                                }, 100);
-                            } else {
-                                console.error('Init function not found:', initFuncName);
-                                window.location.reload();
-                            }
-                        } else {
-                            console.error('Could not extract function name');
-                            window.location.reload();
-                        }
-                    } catch (err) {
-                        console.error('Failed to initialize game:', err);
-                        window.location.reload();
-                    }
-                } else {
-                    window.location.reload();
-                }
+                GamesXBlockMatchingInit(runtime, element);
+                setTimeout(function() {
+                    $('.matching-start-button', element).click();
+                }, 100);
             },
             error: function(xhr, status, error) {
                 console.error('Failed to refresh game:', error);
@@ -103,95 +79,20 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
     }
 
     $('.matching-start-button', element).off('click').on('click', function() {
-        if (!matching_key) {
-            alert('Error: Game not initialized properly');
-            return;
+        if (allPages && allPages[currentPageIndex]) {
+            currentPagePairs = allPages[currentPageIndex].left_items.length;
         }
 
-        const spinner = $('.matching-loading-spinner', element);
-        const startButton = $('.matching-start-button', element);
+        $('.matching-start-screen', element).remove();
+        $('.matching-grid', element).addClass('active');
+        $('.matching-footer', element).addClass('active');
 
-        spinner.addClass('active');
-        startButton.prop('disabled', true);
-
-        $.ajax({
-            type: 'POST',
-            url: runtime.handlerUrl(element, 'start_matching_game'),
-            data: JSON.stringify({ matching_key }),
-            contentType: 'application/json',
-            dataType: 'json',
-            success: function(response) {
-                if (response.success && response.data) {
-                    const entries = response.data;
-                    indexLink = {};
-                    if (Array.isArray(entries)) {
-                        entries.forEach((entry, selfIdx) => {
-                            if (entry && typeof entry === 'string') {
-                                const parts = entry.split('-');
-                                if (parts.length === 5) {
-                                    const indexHex = parts[1] + parts[3];
-                                    indexLink[selfIdx] = parseInt(indexHex, 16);
-                                }
-                            }
-                        });
-                    }
-
-                    // Set current page pair count
-                    if (allPages && allPages[currentPageIndex]) {
-                        currentPagePairs = allPages[currentPageIndex].left_items.length;
-                    }
-
-                    $('.matching-start-screen', element).remove();
-                    $('.matching-grid', element).addClass('active');
-                    $('.matching-footer', element).addClass('active');
-
-                    if (has_timer) {
-                        startTimer();
-                    }
-                    setTimeout(function() {
-                        $('.matching-box', element).first().focus();
-                    }, 100);
-                } else {
-                    alert('Error loading game: ' + (response.error || 'Unknown error'));
-                    spinner.removeClass('active');
-                    startButton.prop('disabled', false);
-                }
-            },
-            error: function(xhr, status, error) {
-                if (xhr.status === 404) {
-                    isPreviewMode = true;
-                    indexLink = {};
-                    let idx = 0;
-                    allPages.forEach(page => {
-                        page.left_items.forEach(() => {
-                            const termIdx = idx++;
-                            const defIdx = idx++;
-                            indexLink[termIdx] = defIdx;
-                            indexLink[defIdx] = termIdx;
-                        });
-                    });
-                    if (allPages && allPages[currentPageIndex]) {
-                        currentPagePairs = allPages[currentPageIndex].left_items.length;
-                    }
-
-                    $('.matching-start-screen', element).remove();
-                    $('.matching-grid', element).addClass('active');
-                    $('.matching-footer', element).addClass('active');
-
-                    if (has_timer) {
-                        startTimer();
-                    }
-                    setTimeout(function() {
-                        $('.matching-box', element).first().focus();
-                    }, 100);
-                    spinner.removeClass('active');
-                    return;
-                }
-                alert('Failed to start game. Please try again.');
-                spinner.removeClass('active');
-                startButton.prop('disabled', false);
-            }
-        });
+        if (has_timer) {
+            startTimer();
+        }
+        setTimeout(function() {
+            $('.matching-box', element).first().focus();
+        }, 100);
     });
 
     $('.matching-end-button', element).off('click').on('click', function() {
@@ -199,7 +100,6 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
     });
 
     let firstSelection = null;
-    const matched = new Set();
     let matchCount = 0;
     let currentPagePairs = 0;
 
@@ -256,7 +156,6 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
 
         // Reset match count for new page
         matchCount = 0;
-        matched.clear();
         firstSelection = null;
 
         // Get next page data
@@ -273,8 +172,8 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
         nextPage.left_items.forEach(item => {
             const wrapper = $('<div class="matching-box-wrapper"></div>');
             const box = $('<div class="matching-box"></div>')
-                .attr('data-index', `matching-key-${item.index}`)
                 .attr('data-item-type', 'term')
+                .attr('data-match', item.match)
                 .attr('title', item.text)
                 .attr('role', 'button')
                 .attr('tabindex', '0');
@@ -288,8 +187,8 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
         nextPage.right_items.forEach(item => {
             const wrapper = $('<div class="matching-box-wrapper"></div>');
             const box = $('<div class="matching-box"></div>')
-                .attr('data-index', `matching-key-${item.index}`)
                 .attr('data-item-type', 'definition')
+                .attr('data-hash', item.hash)
                 .attr('title', item.text)
                 .attr('role', 'button')
                 .attr('tabindex', '0');
@@ -381,24 +280,6 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
             return;
         }
 
-        // In preview mode, skip server call and show completion directly
-        if (isPreviewMode) {
-            $('.matching-end-screen', element).addClass('active');
-            $('.matching-grid', element).remove();
-            $('.matching-footer', element).remove();
-            $('.matching-new-best', element).addClass('active');
-            $('.matching-prev-best', element).remove();
-            $('#matching-current-result', element).text(formatTime(timeSeconds));
-            $('.matching-new-prev-best', element).remove();
-
-            if (typeof GamesConfetti !== 'undefined') {
-                GamesConfetti.trigger($('.confetti-container', element), 20);
-            }
-            announce('Congratulations! You matched all items.');
-            $('.matching-end-screen-content', element).focus();
-            return;
-        }
-
         $.ajax({
             type: 'POST',
             url: runtime.handlerUrl(element, 'complete_matching_game'),
@@ -444,12 +325,8 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
 
     function handleBoxClick() {
         const box = $(this);
-        if (!indexLink) return;
-        const idxStr = box.data('index');
-        if (!idxStr) return;
-        const idx = parseInt(idxStr.replace('matching-key-', ''), 10);
-        if (Number.isNaN(idx)) return;
-        if (matched.has(idx)) return;
+        if (box.hasClass('matched')) return;
+        const type = box.data('itemType');
 
         if (firstSelection && firstSelection[0].is(box)) {
             clearSelectionVisual(box);
@@ -457,29 +334,45 @@ function GamesXBlockMatchingInit(runtime, element, pages, matching_key) {
             return;
         }
 
+        if (firstSelection && firstSelection[1] === type) {
+            clearSelectionVisual(firstSelection[0]);
+            firstSelection = null;
+        }
+
         box.addClass('selected');
         box.attr('aria-pressed', 'true');
         if (!firstSelection) {
-            firstSelection = [box, idx];
+            firstSelection = [box, type];
             return;
         }
 
-        const [prevBox, prevIdx] = firstSelection;
+        const [prevBox, prevType] = firstSelection;
         firstSelection = null;
-        if (prevIdx === idx) {
-            clearSelectionVisual(prevBox);
-            clearSelectionVisual(box);
-            return;
-        }
+        const termBox = prevType === 'term' ? prevBox : box;
+        const defBox  = prevType === 'term' ? box : prevBox;
+        const defHash      = String(defBox.data('hash')).trim();
+        const expectedHash = String(termBox.data('match')).trim();
 
-        const partnerOfPrev = indexLink[prevIdx];
-        const partnerOfCurr = indexLink[idx];
-        if (partnerOfPrev === idx && partnerOfCurr === prevIdx) {
-            markMatch(prevBox, box);
-            matched.add(prevIdx);
-            matched.add(idx);
+        if (expectedHash === defHash) {
+            markMatch(termBox, defBox);
         } else {
-            markIncorrect(prevBox, box);
+            const termText = termBox.find('.matching-box-text').text().trim();
+            let resolvedTerm = null;
+            $('.matching-box[data-item-type="term"]', element).not('.matched').each(function() {
+                const $t = $(this);
+                if ($t.find('.matching-box-text').text().trim() === termText
+                        && String($t.data('match')).trim() === defHash) {
+                    resolvedTerm = $t;
+                    return false; // break
+                }
+            });
+
+            if (resolvedTerm) {
+                resolvedTerm.attr('data-match', expectedHash).data('match', expectedHash);
+                markMatch(termBox, defBox);
+            } else {
+                markIncorrect(termBox, defBox);
+            }
         }
     }
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def package_data(pkg, roots):
 
 setup(
     name="edx-games",
-    version="1.0.15",
+    version="1.0.16",
     description="Interactive games XBlock for Open edX - Create flashcards and matching games with image support",
     author="edX",
     author_email="edx@edx.org",

--- a/tests/handlers/test_matching_handlers.py
+++ b/tests/handlers/test_matching_handlers.py
@@ -1,8 +1,7 @@
 """
 Tests for flashcards and matching handlers.
 """
-import json
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 from django.test import TestCase
 from faker import Faker
 from xblock.field_data import DictFieldData
@@ -65,44 +64,16 @@ class TestMatchingHandlers(TestCase):
         mock_resource_string.return_value = b'<div>{{ total_pages }}</div>'
         # Add enough cards to create multiple pages (6 cards per page by default)
         cards = []
-        for i in range(15):
-            cards.append({CARD_FIELD.TERM: self.fake.word(), CARD_FIELD.DEFINITION: self.fake.sentence()})
+        for _ in range(15):
+            cards.append({
+                CARD_FIELD.TERM: self.fake.word(),
+                CARD_FIELD.DEFINITION: self.fake.sentence()
+                })
         self.xblock.cards = cards
 
         frag = MatchingHandlers.student_view(self.xblock)
 
         self.assertIsNotNone(frag)
-
-    # Tests for get_matching_key_mapping
-    def test_get_matching_key_mapping_success(self):
-        """Test getting matching key mapping with valid encrypted data."""
-        from games.handlers.common import CommonHandlers
-
-        key = CommonHandlers.generate_encryption_key(self.xblock)
-        test_data = [self.fake.word(), self.fake.word()]
-        encrypted = CommonHandlers.encrypt_data(test_data, key)
-
-        data = {'matching_key': encrypted}
-        result = MatchingHandlers.get_matching_key_mapping(self.xblock, data)
-
-        self.assertTrue(result['success'])
-        self.assertEqual(result['data'], test_data)
-
-    def test_get_matching_key_mapping_missing_key(self):
-        """Test get_matching_key_mapping fails when key is missing."""
-        data = {}
-        result = MatchingHandlers.get_matching_key_mapping(self.xblock, data)
-
-        self.assertFalse(result['success'])
-        self.assertIn('Missing matching_key', result['error'])
-
-    def test_get_matching_key_mapping_invalid_encryption(self):
-        """Test get_matching_key_mapping fails with invalid encrypted data."""
-        data = {'matching_key': self.fake.sha256()}
-        result = MatchingHandlers.get_matching_key_mapping(self.xblock, data)
-
-        self.assertFalse(result['success'])
-        self.assertIn('Failed to decrypt', result['error'])
 
     # Tests for refresh_game
     @patch.object(MatchingHandlers, 'student_view')

--- a/tests/test_games.py
+++ b/tests/test_games.py
@@ -8,6 +8,7 @@ import json
 from unittest.mock import Mock, patch
 import pytest
 from xblock.field_data import DictFieldData
+from xblock.fields import Scope
 from xblock.test.tools import TestRuntime
 
 from games.games import GamesXBlock
@@ -215,26 +216,6 @@ class TestGamesXBlockHandlers:
         # Result is a Response object
         assert result.status == '200 OK'
 
-    @patch('games.handlers.matching.MatchingHandlers.get_matching_key_mapping')
-    def test_start_matching_game_handler(self, mock_handler):
-        """Test start_matching_game handler delegates to MatchingHandlers."""
-        mock_handler.return_value = {
-            'success': True,
-            'key_mapping': {},
-        }
-
-        # Create mock request with method and body attributes
-        mock_request = Mock()
-        mock_request.method = 'POST'
-        mock_request.body = json.dumps({}).encode('utf-8')
-
-        result = self.block.start_matching_game(mock_request, '')
-
-        # Verify the handler was called
-        mock_handler.assert_called_once()
-        # Result is a Response object
-        assert result.status == '200 OK'
-
 
 @pytest.mark.django_db
 class TestGamesXBlockFieldScopes:
@@ -254,30 +235,24 @@ class TestGamesXBlockFieldScopes:
 
     def test_title_is_content_scoped(self):
         """Test that title field has content scope."""
-        from xblock.fields import Scope
         assert self.block.fields['title'].scope == Scope.content
 
     def test_cards_is_content_scoped(self):
         """Test that cards field has content scope."""
-        from xblock.fields import Scope
         assert self.block.fields['cards'].scope == Scope.content
 
     def test_best_time_is_user_state_scoped(self):
         """Test that best_time field has user_state scope."""
-        from xblock.fields import Scope
         assert self.block.fields['best_time'].scope == Scope.user_state
 
     def test_game_type_is_settings_scoped(self):
         """Test that game_type field has settings scope."""
-        from xblock.fields import Scope
         assert self.block.fields['game_type'].scope == Scope.settings
 
     def test_is_shuffled_is_settings_scoped(self):
         """Test that is_shuffled field has settings scope."""
-        from xblock.fields import Scope
         assert self.block.fields['is_shuffled'].scope == Scope.settings
 
     def test_has_timer_is_settings_scoped(self):
         """Test that has_timer field has settings scope."""
-        from xblock.fields import Scope
         assert self.block.fields['has_timer'].scope == Scope.settings


### PR DESCRIPTION
**Description**

- Replaced ID-based matching with content-based (text + HMAC) matching.
- Fixes incorrect matches when multiple terms share the same definition.
- Removes encrypted key mapping and related handler/API.
- Simplifies frontend by embedding matching data directly.
- Enables many-to-many matching and improves overall reliability.

**Jira**

- https://2u-internal.atlassian.net/browse/TNL2-550

**Version**

- 1.0.16