### PR TITLE
fix(flashcards): prevent unit page from auto-scrolling to flashcards …

### DIFF
--- a/games/static/js/src/flashcards.js
+++ b/games/static/js/src/flashcards.js
@@ -136,7 +136,13 @@ function GamesXBlockFlashcardsInit(runtime, element, cards) {
         $cardWrapper.addClass('active');
         $footer.addClass('active');
         renderCard();
-        $card.focus();
+        // preventScroll keeps keyboard focus on the card without scrolling
+        // the unit page (LP-859). Fall back to jQuery focus if unsupported.
+        if ($card[0] && $card[0].focus) {
+            $card[0].focus({ preventScroll: true });
+        } else {
+            $card.focus();
+        }
     }
 
     // Event handlers
@@ -185,9 +191,10 @@ function GamesXBlockFlashcardsInit(runtime, element, cards) {
         }
     });
 
-    // Focus the start button on load and announce the game
+    // Announce the game on load. Do NOT focus the start button here:
+    // calling .focus() on an off-screen element scrolls the unit page down
+    // to the flashcards (LP-859). Keyboard users reach Start by tabbing.
     setTimeout(function() {
-        $startButton.focus();
         announce('Flashcard game. Press Start to begin.');
     }, 300);
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def package_data(pkg, roots):
 
 setup(
     name="edx-games",
-    version="1.0.17",
+    version="1.0.18",
     description="Interactive games XBlock for Open edX - Create flashcards and matching games with image support",
     author="edX",
     author_email="edx@edx.org",

--- a/tests/handlers/test_flashcards_handlers.py
+++ b/tests/handlers/test_flashcards_handlers.py
@@ -66,3 +66,24 @@ class TestFlashcardsHandlers(TestCase):
 
         self.assertIsNotNone(frag)
         self.assertIn('2', frag.content)
+
+
+class TestFlashcardsAutoscrollRegression(TestCase):
+    """LP-859: flashcards must not auto-focus the start button on load,
+    which scrolled the unit page down to the flashcards."""
+
+    def _read_js(self):
+        import pkg_resources
+        return pkg_resources.resource_string(
+            "games.handlers.flashcards", "../static/js/src/flashcards.js"
+        ).decode("utf-8")
+
+    def test_no_onload_start_button_focus(self):
+        """The init setTimeout must not call $startButton.focus() (LP-859)."""
+        js = self._read_js()
+        self.assertNotIn("$startButton.focus()", js)
+
+    def test_onload_announcement_retained(self):
+        """Screen-reader announcement on load must remain."""
+        js = self._read_js()
+        self.assertIn("Flashcard game. Press Start to begin.", js)


### PR DESCRIPTION
### Summary
  When a learner navigated to a unit whose **first component is a video** and **second component is a flashcards game**, the page automatically scrolled down to the flashcards instead of
  staying at the top of the unit. This PR keeps the learner at the top of the unit page.

  ### Problem
  - **Reported behavior:** Navigating into the unit jumps the viewport down to the flashcards, skipping past the video.
  - **Acceptance criterion:** The learner should land at the **top** of the unit page.

### Jira ticket
[LP-859](https://2u-internal.atlassian.net/browse/LP-859)